### PR TITLE
restrict the operator when installed via OLM to only see secrets to support default use-case

### DIFF
--- a/manifests/kiali-community/1.39.0/manifests/kiali.v1.39.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.39.0/manifests/kiali.v1.39.0.clusterserviceversion.yaml
@@ -274,9 +274,16 @@ spec:
           - secrets
           verbs:
           - create
-          - get
           - list
           - watch
+        - apiGroups: [""]
+          resourceNames:
+          - cacerts
+          - istio-ca-secret
+          resources:
+          - secrets
+          verbs:
+          - get
         - apiGroups: [""]
           resourceNames:
           - kiali-signing-key

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -315,9 +315,16 @@ spec:
           - secrets
           verbs:
           - create
-          - get
           - list
           - watch
+        - apiGroups: [""]
+          resourceNames:
+          - cacerts
+          - istio-ca-secret
+          resources:
+          - secrets
+          verbs:
+          - get
         - apiGroups: [""]
           resourceNames:
           - kiali-signing-key

--- a/manifests/kiali-upstream/1.39.0/manifests/kiali.v1.39.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.39.0/manifests/kiali.v1.39.0.clusterserviceversion.yaml
@@ -274,9 +274,16 @@ spec:
           - secrets
           verbs:
           - create
-          - get
           - list
           - watch
+        - apiGroups: [""]
+          resourceNames:
+          - cacerts
+          - istio-ca-secret
+          resources:
+          - secrets
+          verbs:
+          - get
         - apiGroups: [""]
           resourceNames:
           - kiali-signing-key


### PR DESCRIPTION
cc @leandroberetta 

Proposal to restrict the operator secret permissions. This would go with https://github.com/kiali/kiali-operator/pull/378

The problem here is if any service mesh tenant has other named secrets that Kiali needs to see, the user has to manually update this role. This is actually not a horrible thing in my mind (it forces the user to think before they grant these privileges to the operator service account). But it will be an annoyance for users that need to do this.

I am trying to figure out the best way to tell a user how to update the operator's cluster role to add secrets to this list, but it is very difficult (if not impossible) to do it in a single kubectl command that patches the rule list item. It may be best just to tell the user how to add a new rule to the role permissions. I'm still looking at this to find the best way to do it. This is something we'll need to document in the FAQ if we do this.